### PR TITLE
replace match query with match phrase query in threat intel APIs to avoid tokenization/analysis of value

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportGetIocFindingsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/TransportGetIocFindingsAction.java
@@ -120,7 +120,8 @@ public class TransportGetIocFindingsAction extends HandledTransportAction<GetIoc
         List<String> iocIds = request.getIocIds();
         if (iocIds != null && !iocIds.isEmpty()) {
             BoolQueryBuilder iocIdQueryBuilder = QueryBuilders.boolQuery();
-            iocIds.forEach(it -> iocIdQueryBuilder.should(QueryBuilders.matchQuery("ioc_feed_ids.ioc_id", it)));
+            // can't use match query because it analyzes the value and considers `hyphens` as word separators
+            iocIds.forEach(it -> iocIdQueryBuilder.should(QueryBuilders.matchPhraseQuery("ioc_feed_ids.ioc_id", it)));
             queryBuilder.filter(iocIdQueryBuilder);
         }
 

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportGetThreatIntelAlertsAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportGetThreatIntelAlertsAction.java
@@ -108,8 +108,8 @@ public class TransportGetThreatIntelAlertsAction extends HandledTransportAction<
         SearchRequest threatIntelMonitorsSearchRequest = new SearchRequest();
         threatIntelMonitorsSearchRequest.indices(".opendistro-alerting-config");
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchQuery("monitor.owner", PLUGIN_OWNER_FIELD)));
-        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchQuery("monitor.monitor_type", ThreatIntelMonitorRunner.THREAT_INTEL_MONITOR_TYPE)));
+        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchPhraseQuery("monitor.owner", PLUGIN_OWNER_FIELD)));
+        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchPhraseQuery("monitor.monitor_type", ThreatIntelMonitorRunner.THREAT_INTEL_MONITOR_TYPE)));
         threatIntelMonitorsSearchRequest.source(new SearchSourceBuilder().query(boolQueryBuilder));
         transportSearchThreatIntelMonitorAction.execute(new SearchThreatIntelMonitorRequest(threatIntelMonitorsSearchRequest), ActionListener.wrap(
                 searchResponse -> {
@@ -141,7 +141,7 @@ public class TransportGetThreatIntelAlertsAction extends HandledTransportAction<
         BoolQueryBuilder monitorIdMatchQuery = QueryBuilders.boolQuery();
         for (String monitorId : monitorIds) {
             monitorIdMatchQuery.should(QueryBuilders.boolQuery()
-                    .must(QueryBuilders.matchQuery("monitor_id", monitorId)));
+                    .must(QueryBuilders.matchPhraseQuery("monitor_id", monitorId)));
 
         }
         queryBuilder.filter(monitorIdMatchQuery);

--- a/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportUpdateThreatIntelAlertStatusAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/threatIntel/transport/monitor/TransportUpdateThreatIntelAlertStatusAction.java
@@ -102,8 +102,8 @@ public class TransportUpdateThreatIntelAlertStatusAction extends HandledTranspor
         SearchRequest threatIntelMonitorsSearchRequest = new SearchRequest();
         threatIntelMonitorsSearchRequest.indices(".opendistro-alerting-config");
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchQuery("monitor.owner", PLUGIN_OWNER_FIELD)));
-        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchQuery("monitor.monitor_type", ThreatIntelMonitorRunner.THREAT_INTEL_MONITOR_TYPE)));
+        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchPhraseQuery("monitor.owner", PLUGIN_OWNER_FIELD)));
+        boolQueryBuilder.should().add(new BoolQueryBuilder().must(QueryBuilders.matchPhraseQuery("monitor.monitor_type", ThreatIntelMonitorRunner.THREAT_INTEL_MONITOR_TYPE)));
         threatIntelMonitorsSearchRequest.source(new SearchSourceBuilder().query(boolQueryBuilder));
         transportSearchThreatIntelMonitorAction.execute(new SearchThreatIntelMonitorRequest(threatIntelMonitorsSearchRequest), ActionListener.wrap(
                 searchResponse -> {
@@ -174,22 +174,22 @@ public class TransportUpdateThreatIntelAlertStatusAction extends HandledTranspor
         BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
         BoolQueryBuilder monitorIdMatchQuery = QueryBuilders.boolQuery();
         for (String monitorId : monitorIds) {
-            monitorIdMatchQuery.should(QueryBuilders.matchQuery(ThreatIntelAlert.MONITOR_ID_FIELD, monitorId));
+            monitorIdMatchQuery.should(QueryBuilders.matchPhraseQuery(ThreatIntelAlert.MONITOR_ID_FIELD, monitorId));
 
         }
         queryBuilder.filter(monitorIdMatchQuery);
 
         BoolQueryBuilder idMatchQuery = QueryBuilders.boolQuery();
         for (String id : request.getAlertIds()) {
-            idMatchQuery.should(QueryBuilders.matchQuery("_id", id));
+            idMatchQuery.should(QueryBuilders.matchPhraseQuery("_id", id));
 
         }
         queryBuilder.filter(idMatchQuery);
 
         if (request.getState() == Alert.State.COMPLETED) {
-            queryBuilder.filter(QueryBuilders.matchQuery(ThreatIntelAlert.STATE_FIELD, Alert.State.ACKNOWLEDGED.toString()));
+            queryBuilder.filter(QueryBuilders.matchPhraseQuery(ThreatIntelAlert.STATE_FIELD, Alert.State.ACKNOWLEDGED.toString()));
         } else if (request.getState() == Alert.State.ACKNOWLEDGED) {
-            queryBuilder.filter(QueryBuilders.matchQuery(ThreatIntelAlert.STATE_FIELD, Alert.State.ACTIVE.toString()));
+            queryBuilder.filter(QueryBuilders.matchPhraseQuery(ThreatIntelAlert.STATE_FIELD, Alert.State.ACTIVE.toString()));
         } else {
             log.error("Threat intel monitor not found. No alerts to update");
             listener.onFailure(new SecurityAnalyticsException("Threat intel monitor not found. No alerts to update",
@@ -274,14 +274,14 @@ public class TransportUpdateThreatIntelAlertStatusAction extends HandledTranspor
         BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
         BoolQueryBuilder monitorIdMatchQuery = QueryBuilders.boolQuery();
         for (String monitorId : monitorIds) {
-            monitorIdMatchQuery.should(QueryBuilders.matchQuery(ThreatIntelAlert.MONITOR_ID_FIELD, monitorId));
+            monitorIdMatchQuery.should(QueryBuilders.matchPhraseQuery(ThreatIntelAlert.MONITOR_ID_FIELD, monitorId));
 
         }
         queryBuilder.filter(monitorIdMatchQuery);
 
         BoolQueryBuilder idMatchQuery = QueryBuilders.boolQuery();
         for (String id : alertIds) {
-            idMatchQuery.should(QueryBuilders.matchQuery("_id", id));
+            idMatchQuery.should(QueryBuilders.matchPhraseQuery("_id", id));
 
         }
         queryBuilder.filter(idMatchQuery);

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/ThreatIntelMonitorRestApiIT.java
@@ -246,6 +246,14 @@ public class ThreatIntelMonitorRestApiIT extends SecurityAnalyticsRestTestCase {
             assertEquals(2, numFindings);
         });
 
+        // Use ListIOCs API with large size to ensure matchQuery related bug is not throwing too many bool clauses exception
+        listIocsUri = String.format("?%s=%s", "size", 1000);
+        listIocsResponse = makeRequest(client(), "GET", SecurityAnalyticsPlugin.LIST_IOCS_URI, Collections.emptyMap(), null);
+        assertEquals(200, listIocsResponse.getStatusLine().getStatusCode());
+        listIocsResponseMap = responseAsMap(listIocsResponse);
+        iocsMap = (List<Map<String, Object>>) listIocsResponseMap.get("iocs");
+        assertTrue(2 < iocsMap.size()); // number should be greater than custom source iocs because of default config
+
         //alerts via system index search
         searchHits = executeSearch(ThreatIntelAlertService.THREAT_INTEL_ALERT_ALIAS_NAME, matchAllRequest);
         Assert.assertEquals(4, searchHits.size());


### PR DESCRIPTION

### Description
replace match query with match phrase query in threat intel to avoid tokenization/analysis of value in Threat intel flows
 